### PR TITLE
Naive implementation of multiple loaders

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -43,15 +43,18 @@ if __name__ == '__main__':
                       type=int, default=1)
   parser.add_argument('-v', '--videos', help='Total number of videos to run',
                       type=int, default=2000)
+  parser.add_argument('-l', '--loaders', help='Number of loader processes to spawn',
+                      type=int, default=1)
   args = parser.parse_args()
   print('Args:', args)
 
-  job_id = '%s-mi%d-g%d-r%d-b%d-v%d' % (dt.today().strftime('%y%m%d_%H%M%S'),
-                                        args.mean_interval_ms,
-                                        args.gpus,
-                                        args.replicas_per_gpu,
-                                        args.batch_size,
-                                        args.videos)
+  job_id = '%s-mi%d-g%d-r%d-b%d-v%d-l%d' % (dt.today().strftime('%y%m%d_%H%M%S'),
+                                            args.mean_interval_ms,
+                                            args.gpus,
+                                            args.replicas_per_gpu,
+                                            args.batch_size,
+                                            args.videos,
+                                            args.loaders)
 
   # assume homogeneous placement of runners
   # in case of a heterogeneous placement, this needs to be changed accordingly
@@ -60,15 +63,13 @@ if __name__ == '__main__':
   # barrier to ensure all processes start at the same time
   sta_bar_semaphore = Semaphore(0)
   sta_bar_value = Value('i', 0)
-  # one client + one loader + one main process (this one) = 3
-  # this needs to be changed if there are multiple loaders
-  # TODO #4: Multiple loaders
-  sta_bar_total = num_runners + 3
+  # runners + loaders + one client + one main process (this one)
+  sta_bar_total = num_runners + args.loaders + 2
 
   # barrier to ensure all processes finish at the same time
   fin_bar_semaphore = Semaphore(0)
   fin_bar_value = Value('i', 0)
-  fin_bar_total = num_runners + 3
+  fin_bar_total = num_runners + args.loaders + 2
 
   # queue between client and loader
   filename_queue = SimpleQueue()
@@ -76,15 +77,16 @@ if __name__ == '__main__':
   data_queue = SimpleQueue()
 
   process_client = Process(target=client,
-                           args=(filename_queue, args.mean_interval_ms, args.videos,
+                           args=(filename_queue, args.mean_interval_ms,
+                                 args.videos, args.loaders,
                                  sta_bar_semaphore, sta_bar_value, sta_bar_total,
                                  fin_bar_semaphore, fin_bar_value, fin_bar_total))
 
-  # TODO #4: Multiple loaders
-  process_loader = Process(target=loader,
-                           args=(filename_queue, data_queue, num_runners,
-                                 sta_bar_semaphore, sta_bar_value, sta_bar_total,
-                                 fin_bar_semaphore, fin_bar_value, fin_bar_total))
+  process_loader_list = [Process(target=loader,
+                                 args=(filename_queue, data_queue, num_runners, l,
+                                       sta_bar_semaphore, sta_bar_value, sta_bar_total,
+                                       fin_bar_semaphore, fin_bar_value, fin_bar_total))
+                         for l in range(args.loaders)]
 
   process_runner_list = []
   for g in range(args.gpus):
@@ -96,7 +98,7 @@ if __name__ == '__main__':
                                                fin_bar_semaphore, fin_bar_value, fin_bar_total)))
 
 
-  for p in [process_client, process_loader] + process_runner_list:
+  for p in [process_client] + process_loader_list + process_runner_list:
     p.start()
 
   # we should be able to hide this whole semaphore mess in a
@@ -127,7 +129,7 @@ if __name__ == '__main__':
 
 
   print('Waiting for child processes to return...')
-  for p in [process_client, process_loader] + process_runner_list:
+  for p in [process_client] + process_loader_list + process_runner_list:
     p.join()
   
 

--- a/client.py
+++ b/client.py
@@ -4,7 +4,7 @@ Reads video names from a hard-coded file path and sends them to the filename
 queue, one at a time. The interval time between enqueues is sampled from an
 exponential distribution, to model video inference queries as a Poisson process.
 """
-def client(filename_queue, beta, num_videos,
+def client(filename_queue, beta, num_videos, num_loaders,
            sta_bar_semaphore, sta_bar_value, sta_bar_total,
            fin_bar_semaphore, fin_bar_value, fin_bar_total):
   # PyTorch seems to have an issue with sharing modules between
@@ -51,7 +51,8 @@ def client(filename_queue, beta, num_videos,
     time.sleep(exponential(float(beta) / 1000)) # milliseconds --> seconds
 
   # mark the end of the input stream
-  filename_queue.put(None)
+  for _ in range(num_loaders):
+    filename_queue.put(None)
 
   with fin_bar_value.get_lock():
     fin_bar_value.value += 1

--- a/scripts/latency_summary.py
+++ b/scripts/latency_summary.py
@@ -14,10 +14,16 @@ df = df[df.num_replicas_per_gpu == 1]
 # filter out items s.t. batch_size != 1
 df = df[df.batch_size == 1]
 
+# filter out items s.t. num_loaders != 1
+df = df[df.num_loaders == 1]
+
 # remove irrelevant columns
-df = df.drop(['num_replicas_per_gpu',
-              'batch_size',
-              'num_videos'], axis=1)
+df = df.drop([
+    'num_replicas_per_gpu',
+    'batch_size',
+    'num_videos',
+    'num_loaders',
+    ], axis=1)
 
 # calculate latencies
 df['filename_queue_wait'] = (df['time_loader_start'] - df['time_enqueue_filename']) * 1000


### PR DESCRIPTION
Closes #4.

This PR
* allows multiple loaders to placed for the test benchmark, one per GPU.

The loader code is very slightly modified to allow placement on any available GPU. Now, the benchmark script spawns several loaders, placing at most one on each GPU. The number of loaders to use can be specified with the new command line argument `--loaders` (`-l`).
This PR is merely a naive, small addition regarding multiple processes. We can build upon this later when we start to experiment with non-trivial, asymmetrical step placements such as multiple loaders on a single GPU.

Note that the addition of `--loaders` must be reflected on the parsing scripts in `scripts`, as well. Our previous logs can be reused by adding `-l1` to the log directory name and `loaders=1` to the log meta file (see the changes in `parse_utils.py` for details).