### PR TITLE
Sanity check on user given arguments 

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -29,7 +29,7 @@ def sanity_check(args):
   """
   import os
   import sys
-  from py3nvml import *
+  from py3nvml import py3nvml
 
   # Case 1: Check whether arguments are positive integers 
   invalid_argument = []


### PR DESCRIPTION
### This PR serves to check validity of user-given arguments. 

**Prerequisite:** 
`pip install py3nvml` is required for this PR. 

This PR mainly deals with three cases. 

**`Case 1: Integers less than 1`**
All the arguments expect the given numbers to be positive integers. We will terminate the main process by listing all the arguments and their values which are less than one. 
```bash
python benchmark.py -mi -10 -r -20
Args: Namespace(batch_size=1, gpus=1, loaders=1, mean_interval_ms=-10, replicas_per_gpu=-20, videos=2000)
[WARNING] Invalid number for mean_interval_ms. (-10)
[WARNING] Invalid number for replicas_per_gpu. (-20)
```

**`Case 2: Wrong type given for environment variable 'CUDA_VISIBLE_DEVICES'`**
If user gave an invalid type of value that is not a string of integers for 'CUDA_VISIBLE_DEVICES', the program will also exit by returning 'ValueError'. 

**`Case 3: Invalid number of GPUs`**
The following variables are used to deal with this Case 3. 
* args.gpus: the argument user gives for the # of GPUs 
* visible_gpu_idx: A list of GPUs that are visible to the user. This contains the parsed values the user gave for 'CUDA_VISIBLE_DEVICES'. 
* available_gpu_idx: This is an intersection of GPUs that are visible to the user and GPUs whose memory is not used at all. The numbers of GPUs with free memory were retrieved by using py3nvml.  

The program will exit if user requires more GPUs than the number of GPUs that are both free and visible.

Test Setting:
* CUDA_VISIBLE_DEVICES=0, 1, 2
* GPUs 2, 3 in Use
* User wants to use 3 GPUs (args.gpus = 3)

```bash
python benchmark.py -g 3
Args: Namespace(batch_size=1, gpus=3, loaders=1, mean_interval_ms=100, replicas_per_gpu=1, videos=2000)
[WARNING] Exceeds the number of available GPUs (Requested: 3 / Available: 2 [0, 1]).
```