### PR TITLE
Change the way to express the constraints of command-line arguments 

### DIFF
--- a/arg_utils.py
+++ b/arg_utils.py
@@ -1,11 +1,15 @@
 import argparse
 def positive_int(x):
+  """Converts the argument to integer and checks whether the value is positive.
+  """
   x = int(x)
   if x <= 0:
     raise argparse.ArgumentTypeError("Should be a positive integer but %d is given" % x)
   return x
 
 def nonnegative_int(x):
+  """Converts the argument to integer and checks whether the value is non-negative.
+  """
   x = int(x)
   if x < 0:
     raise argparse.ArgumentTypeError("Should be a non-negative integer but %d is given" % x)

--- a/benchmark.py
+++ b/benchmark.py
@@ -18,12 +18,9 @@ def sanity_check(args):
   The function 'sanity_check' checks the arguments and terminates when an invalid state is observed. 
 
   The program will terminate in the following situations:
-  TODO Remove
-  1) The current benchmark expects arguments to be positive integers, thus any argument 
-     less than 1 will be considered invalid and lead the program to terminate.  
-  2) The values given for environment variable 'CUDA_VISIBLE_DEVICES' will be checked
+  1) The values given for environment variable 'CUDA_VISIBLE_DEVICES' will be checked
      to see if valid argument is given, and the program will terminate if not so. 
-  3) Here, we will regard GPUs with no process running along with no consumption in memory as 'free'. 
+  2) Here, we will regard GPUs with no process running along with no consumption in memory as 'free'. 
      If a GPU has no process running, but is consuming some memory, we will regard the GPU as 'not-free', 
      and prevent users from using it. If user requires more GPUs than the number of GPUs that are 
      both accessible and free, the program will also terminate. 
@@ -32,25 +29,10 @@ def sanity_check(args):
   import sys
   from py3nvml import py3nvml
 
-  # Case 1: Check whether arguments are positive integers 
-  #invalid_argument = []
-  #for arg in vars(args).keys():
-  #  if isinstance(vars(args)[arg], str):
-  #    # the check below is invalid for strings
-  #    continue
-
-  #  if vars(args)[arg] < 1:  
-  #    invalid_argument.append(arg) 
-  
-  #if len(invalid_argument) > 0:
-  #  for x in invalid_argument:
-  #    print('[WARNING] Invalid number for %s. (%d) ' % (x, vars(args)[x]))
-  #  sys.exit()
-
-  # Case 2: Return 'ValueError' if any types other than integers are set for this environment variable
+  # Case 1: Return 'ValueError' if any types other than integers are set for this environment variable
   visible_gpu_idx = sorted([int(x) for x in os.environ['CUDA_VISIBLE_DEVICES'].split(',')]) 
    
-  # Case 3: Check whether user requires more GPUs than the number of GPUs that are both accessible and free
+  # Case 2: Check whether user requires more GPUs than the number of GPUs that are both accessible and free
   py3nvml.nvmlInit()
  
   # Find the indices of GPUs that are both free and visible


### PR DESCRIPTION
Closes #23 

This PR introduces two custom types for command line arguments: `positive_int` and `nonnegative_int`. They are defined in `arg_utils.py` and can be used in `type` field in `add_arguments()` as in `benchmark.py`.

Some examples to show how it works (`-g`: number of GPUs (positive), `-mi`: mean interval (non-negative)):
```bash
$ (rnb) yunseong@elsa-09:~/snuspl/rnb$ CUDA_VISIBLE_DEVICES=3 python benchmark.py -g 0
usage: benchmark.py [-h] [-mi MEAN_INTERVAL_MS] [-g GPUS]
                    [-r REPLICAS_PER_GPU] [-b BATCH_SIZE] [-v VIDEOS]
                    [-l LOADERS] [-qs QUEUE_SIZE] [-m MODEL]
benchmark.py: error: argument -g/--gpus: Should be a positive integer but 0 is given
$ (rnb) yunseong@elsa-09:~/snuspl/rnb$ CUDA_VISIBLE_DEVICES=3 python benchmark.py -mi -1
usage: benchmark.py [-h] [-mi MEAN_INTERVAL_MS] [-g GPUS]
                    [-r REPLICAS_PER_GPU] [-b BATCH_SIZE] [-v VIDEOS]
                    [-l LOADERS] [-qs QUEUE_SIZE] [-m MODEL]
benchmark.py: error: argument -mi/--mean_interval_ms: Should be a non-negative integer but -1 is given
```