### PR TITLE
Support mean_interval_ms = 0 for maximum throughput measurement

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -179,12 +179,12 @@ if __name__ == '__main__':
   if args.mean_interval_ms > 0:
     client_impl = poisson_client
     client_args = (filename_queue, args.mean_interval_ms,
-                                 args.loaders, termination_flag,
-                                 sta_bar, fin_bar)
+                   args.loaders, termination_flag,
+                   sta_bar, fin_bar)
   else:
     client_impl = bulk_client
     client_args = (filename_queue, args.loaders, args.videos, termination_flag,
-                                 sta_bar, fin_bar)
+                   sta_bar, fin_bar)
   process_client = Process(target=client_impl,
                            args=client_args)
 
@@ -204,7 +204,7 @@ if __name__ == '__main__':
 
     # Create a queue for the processes in this step to put results into.
     # We don't need a queue for the last step, so we add a None placeholder.
-    output_queue = Queue(args.queue_size) if not is_final_step else None
+    output_queue = Queue(queue_size) if not is_final_step else None
     queues.append(output_queue)
 
     model = step['model']

--- a/client.py
+++ b/client.py
@@ -35,7 +35,7 @@ def load_videos():
   return videos
 
 def poisson_client(filename_queue, beta, num_loaders, termination_flag,
-        sta_bar, fin_bar):
+                   sta_bar, fin_bar):
   """Sends loaded video to the filename queue, one at a time.
 
   The interval time between enqueues is sampled from an exponential distribution, 
@@ -84,8 +84,7 @@ def poisson_client(filename_queue, beta, num_loaders, termination_flag,
   fin_bar.wait()
 
 def bulk_client(filename_queue, num_loaders, num_videos, termination_flag,
-           sta_bar_semaphore, sta_bar_value, sta_bar_total,
-           fin_bar_semaphore, fin_bar_value, fin_bar_total):
+                sta_bar, fin_bar):
   """Sends videos to the filename queue in bulk, as many as specified by the argument num_videos.
 
   This implementation is mainly for measuring maximum throughput where latency is not a primary metric. 
@@ -102,8 +101,8 @@ def bulk_client(filename_queue, num_loaders, num_videos, termination_flag,
   video_count = 0
   while video_count < num_videos:
     # come back to the front of the list if we're at the end
-    video_count += 1
     video = videos[video_count % len(videos)]
+    video_count += 1
 
     # create TimeCard instance to measure the time of key events
     time_card = TimeCard()


### PR DESCRIPTION
Resolves #12 

This PR adds support for measuring maximum throughput to process a set of videos.
- In `client.py`, `bulk_client` has been added and the previous one has been renamed to `poisson_client` in a sense that the requests are generated following poisson distribution.
- In `benchmark.py`, the configuration is set differently as per the `mean_interval_ms`.