### PR TITLE
[Minor] Add .vscode in gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 logs
+.vscode


### PR DESCRIPTION
This PR is extremely minor but it would be handy if we ignore the `.vscode` file in our source tree, which is a config file used in Visual Studio Code.