### PR TITLE
Hotfix for preventing processes from hanging before program termination

### DIFF
--- a/client.py
+++ b/client.py
@@ -82,6 +82,7 @@ def poisson_client(filename_queue, beta, num_loaders, termination_flag,
     pass
 
   fin_bar.wait()
+  filename_queue.cancel_join_thread()
 
 def bulk_client(filename_queue, num_loaders, num_videos, termination_flag,
                 sta_bar, fin_bar):
@@ -128,3 +129,4 @@ def bulk_client(filename_queue, num_loaders, num_videos, termination_flag,
     pass
 
   fin_bar.wait()
+  filename_queue.cancel_join_thread()

--- a/runner.py
+++ b/runner.py
@@ -111,6 +111,8 @@ def runner(input_queue, output_queue, num_exit_markers, print_summary,
             pass
 
   fin_bar.wait()
+  if output_queue is not None:
+    output_queue.cancel_join_thread()
 
   if is_final_step:
     # write statistics AFTER the barrier so that
@@ -125,14 +127,3 @@ def runner(input_queue, output_queue, num_exit_markers, print_summary,
       time_card_summary.print_summary(NUM_SKIPS)
       progress_bar.close()
 
-  # We've observed cases where the loader processes do not exit until
-  # all tensors spawned from the loaders are removed from scope (even if they
-  # reach the end of the `loader` function).
-  # We clear the input queue here so loaders can exit successfully.
-  # Note that it doesn't matter if this cleanup takes long, because the
-  # throughput measurement has already been done at the finish barrier above.
-  try:
-    while True:
-      input_queue.get_nowait()
-  except Empty:
-    pass


### PR DESCRIPTION
This PR prevents cases where the client process or runner processes fail to exit and the benchmark never terminates. This is done by letting client and runner processes exit regardless of whether their outputs queues have remaining items or not.

The official Python documentation states that a process may not terminate if it has lingering items alive in a queue (https://docs.python.org/3/library/multiprocessing.html#pipes-and-queues):
> ... if a child process has put items on a queue (and it has not used JoinableQueue.cancel_join_thread), then that process will not terminate until all buffered items have been flushed to the pipe.

I believe this may be a reason why we are experiencing the program hanging issue time to time.
Thus, this PR simply calls `cancel_join_thread` before exiting to ensure a safe exit.