### PR TITLE
Hotfix for not printing summary if log records are not enough

### DIFF
--- a/rnb_logging.py
+++ b/rnb_logging.py
@@ -60,6 +60,10 @@ class TimeCardSummary:
     to skip when calculating average elapsed time.
     """
     for prv, nxt in zip(self.keys[:-1], self.keys[1:]):
+      if len(self.summary[prv]) <= num_skips:
+        print('Not enough log entries (%d records) to print summary!' % len(self.summary[prv]))
+        break
+
       elapsed_time = np.mean((
           np.array(self.summary[nxt][num_skips:]) -
           np.array(self.summary[prv][num_skips:])) * 1000)


### PR DESCRIPTION
This PR avoids trying to print summary even there are not enough records to compute summary. For example, if any queues explode we can see a frustrating log messages as follows:
```
[WARNING] Queue between runner step 0 and 1 is full. Aborting...
 89%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊                               | 8/9 [00:04<00:00,  1.66it/s]Finished processing 9 videos
FINISH! 1560495039.481211
That took 5.334828 seconds
Waiting for child processes to return...
/home/yunseong/miniconda2/envs/rnb/lib/python3.7/site-packages/numpy/core/fromnumeric.py:2920: RuntimeWarning: Mean of empty slice.
  out=out, **kwargs)
/home/yunseong/miniconda2/envs/rnb/lib/python3.7/site-packages/numpy/core/_methods.py:85: RuntimeWarning: invalid value encountered in double_scalars
  ret = ret.dtype.type(ret / rcount)
Average time between enqueue_filename and runner0_start: nan ms
Average time between runner0_start and inference0_start: nan ms
Average time between inference0_start and inference0_finish: nan ms
Average time between inference0_finish and runner1_start: nan ms
Average time between runner1_start and inference1_start: nan ms
Average time between inference1_start and inference1_finish: nan ms
```

Applying this patch changes the log message to be informative:
```
[WARNING] Queue between runner step 0 and 1 is full. Aborting...
 33%|█████████████████████████████████████████████████████████████████████████████████████████████▋                                                                                                                                                                                           | 3/9 [00:04<00:09,  1.64s/it]FINISH! 1560495268.008765
That took 5.390141 seconds
Waiting for child processes to return...
Not enough records (1 samples) to print summary!
```