### PR TITLE
Hotfix: Fix a mistyped variable name (tensor_queue in control.py)

### DIFF
--- a/control.py
+++ b/control.py
@@ -64,10 +64,10 @@ class BenchmarkQueues:
                             for step_idx in range(self.num_steps - 1)]
 
       # The first step will receive filenames from client via filename_queue.
-      self.tensor_queue.insert(0, {0: self.filename_queue})
+      self.tensor_queues.insert(0, {0: self.filename_queue})
 
       # The last step does need an output queue, so we pass None.
-      self.tensor_queue.append({0: None})
+      self.tensor_queues.append({0: None})
 
   def get_tensor_queue(self, step_idx, gpu_idx):
     queue_idx = gpu_idx if self.per_gpu_queue else 0


### PR DESCRIPTION
While running experiments, I've found that we mistyped a variable name in `control.py` in the review process of #48.

An error occurs when `per_gpu_queue=False` since it fails to find the variable `tensor_queue`, which should have been written `tensor_queues`. I apologize to miss this error.
```
[rnb] mi 40
Args: Namespace(batch_size=1, config_file_path='config/r2p1d-whole.json', mean_interval_ms=40, per_gpu_queue=False, queue_size=500, videos=1000)
Traceback (most recent call last):
  File "benchmark.py", line 195, in <module>
    args.per_gpu_queue)
  File "/home/yunseong/snuspl/rnb/control.py", line 67, in __init__
    self.tensor_queue.insert(0, {0: self.filename_queue})
AttributeError: 'BenchmarkQueues' object has no attribute 'tensor_queue'
```