### PR TITLE
Hotfix: Fix overwriting a variable in runner

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -73,8 +73,8 @@ def runner(input_queue, output_queue, print_summary,
 
           if signal is not None:
             # we need to copy values from the designated shared input tensor
-            instance_idx, tensor_idx = signal
-            tensor_event = shared_input_tensors[instance_idx][tensor_idx]
+            signal_instance_idx, tensor_idx = signal
+            tensor_event = shared_input_tensors[signal_instance_idx][tensor_idx]
 
             # Under normal circumstances, the event should not be set yet.
             # However, this may not be true if the job is terminating, in which


### PR DESCRIPTION
The `runner` function in `runner.py` receives `instance_idx` as a function parameter, for creating Signal objects to pass over to the next step.
```python
# pass a Signal object for accessing shared tensors
signal = Signal(instance_idx, shared_output_tensor_counter)
```
Unfortunately, the latest PR #58 added an error of overwriting that parameter with a variable (of the same name) that has a completely different purpose. This bug wasn't observed in that PR because the test case did not actually involve any runner step that handles both shared input and output tensors. Rather, I tripped over this when I was working on #44, which adds a final aggregator step and thus uncovers this hidden error.

I've solved this simply by giving the corresponding variable a different name.