### PR TITLE
Minor: Configure number of shared tensors in configuration file

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -152,21 +152,17 @@ if __name__ == '__main__':
   parser.add_argument('-p', '--per_gpu_queue',
                       help='Whether to place intermediate queues on each GPU',
                       action='store_true')
-  parser.add_argument('-t', '--tensors_per_process',
-                      help='Number of shared output tensors per process',
-                      type=positive_int, default=100)
   args = parser.parse_args()
   print('Args:', args)
   
   sanity_check(args)
 
-  job_id = '%s-mi%d-b%d-v%d-qs%d-p%d-t%d' % (dt.today().strftime('%y%m%d_%H%M%S'),
-                                             args.mean_interval_ms,
-                                             args.batch_size,
-                                             args.videos,
-                                             args.queue_size,
-                                             args.per_gpu_queue,
-                                             args.tensors_per_process)
+  job_id = '%s-mi%d-b%d-v%d-qs%d-p%d' % (dt.today().strftime('%y%m%d_%H%M%S'),
+                                         args.mean_interval_ms,
+                                         args.batch_size,
+                                         args.videos,
+                                         args.queue_size,
+                                         args.per_gpu_queue)
 
   # do a quick pass through the pipeline to count the total number of runners
   with open(args.config_file_path, 'r') as f:
@@ -215,7 +211,7 @@ if __name__ == '__main__':
                            args=client_args)
 
   # create SharedTensors object for managing shared tensors between steps
-  shared_tensors = SharedTensors(pipeline, args.tensors_per_process)
+  shared_tensors = SharedTensors(pipeline)
 
   process_runner_list = []
   for step_idx, step in enumerate(pipeline):

--- a/config/r2p1d-whole.json
+++ b/config/r2p1d-whole.json
@@ -4,7 +4,8 @@
     {
       
       "model": "models.r2p1d.model.R2P1DLoader",
-      "gpus": [0]
+      "gpus": [0],
+      "num_shared_tensors": 100
     },
     {
       "model": "models.r2p1d.model.R2P1DRunner",


### PR DESCRIPTION
This PR changes how to control the number of shared output tensors per process.
Instead of specifying the parameter as a command line argument, I've added the option of setting the parameter differently per step in the configuration file. This way, we can adjust the amount of shared memory between steps depending on the relative speed difference of adjacent steps. The parameter is an optional parameter with a default value of 10 (`DEFAULT_NUM_SHARED_TENSORS`).

For example, if step N is significantly faster than step N-1 & N+1 , then we wouldn't have to allocate many shared tensors between steps N-1 and N because there will always be an available shared tensor for step N-1 to write its outputs. On the other hand, we should give a plenty amount of shared output tensors to step N because it is highly likely that step N will be blocked on N+1's progress.

Example:
```json
{
  "model": "abc",
  "num_shared_tensors": 100
},
{
  "model": "def",
  "num_shared_tensors": 5
}
```