### PR TITLE
Minor: Clean up RunnerModel signature to be more explicit

### DIFF
--- a/client.py
+++ b/client.py
@@ -33,7 +33,7 @@ def poisson_client(video_path_iterator, filename_queue, beta, termination_flag,
     time_card.record('enqueue_filename')
 
     try:
-      filename_queue.put_nowait(((None, video_path), time_card))
+      filename_queue.put_nowait((None, video_path, time_card))
     except Full:
       print('[WARNING] Filename queue is full. Aborting...')
       termination_flag.value = TerminationFlag.FILENAME_QUEUE_FULL
@@ -81,7 +81,7 @@ def bulk_client(video_path_iterator, filename_queue, num_videos, termination_fla
     time_card.record('enqueue_filename')
 
     try:
-      filename_queue.put_nowait(((None, video_path), time_card))
+      filename_queue.put_nowait((None, video_path, time_card))
     except Full:
       print('[WARNING] Filename queue is full. Aborting...')
       termination_flag.value = TerminationFlag.FILENAME_QUEUE_FULL

--- a/models/r2p1d/model.py
+++ b/models/r2p1d/model.py
@@ -74,9 +74,9 @@ class R2P1DRunner(RunnerModel):
     # need to change return value accordingly
     return ((10, 400),)
 
-  def __call__(self, input):
-    (tensor,), _ = input
-    return ((self.model(tensor),), None)
+  def __call__(self, tensors, non_tensors, time_card):
+    tensor = tensors[0]
+    return (self.model(tensor),), None, time_card
 
 class R2P1DVideoPathIterator(VideoPathIterator):
   def __init__(self):
@@ -128,8 +128,8 @@ class R2P1DLoader(RunnerModel):
       pass
     self.loader.flush()
 
-  def __call__(self, input):
-    _, filename = input
+  def __call__(self, tensors, non_tensors, time_card):
+    filename = non_tensors
     self.loader.loadfile(filename)
     for frames in self.loader:
       pass
@@ -137,7 +137,7 @@ class R2P1DLoader(RunnerModel):
 
     frames = frames.float()
     frames = frames.permute(0, 2, 1, 3, 4)
-    return ((frames,), None)
+    return (frames,), None, time_card
 
   def __del__(self):
     self.loader.close()
@@ -201,8 +201,8 @@ class R2P1DSingleStep(RunnerModel):
     self.loader.flush()
     stream.synchronize()
 
-  def __call__(self, input):
-    _, filename = input
+  def __call__(self, tensors, non_tensors, time_card):
+    filename = non_tensors
     self.loader.loadfile(filename)
     for frames in self.loader:
       pass
@@ -211,7 +211,7 @@ class R2P1DSingleStep(RunnerModel):
     frames = frames.float()
     frames = frames.permute(0, 2, 1, 3, 4)
 
-    return ((self.model(frames),), None)
+    return (self.model(frames),), None, time_card
 
   def __del__(self):
     self.loader.close()

--- a/runner.py
+++ b/runner.py
@@ -67,7 +67,7 @@ def runner(input_queue, output_queue, print_summary,
           if tpl is None:
             break
 
-          (signal, non_tensor_inputs), time_card = tpl
+          signal, non_tensor_inputs, time_card = tpl
 
           time_card.record('runner%d_start' % step_idx)
 
@@ -99,8 +99,8 @@ def runner(input_queue, output_queue, print_summary,
 
           time_card.record('inference%d_start' % step_idx)
 
-          tensor_outputs, non_tensor_outputs = \
-              model((tensor_input_placeholder, non_tensor_inputs))
+          tensor_outputs, non_tensor_outputs, time_card = \
+              model(tensor_input_placeholder, non_tensor_inputs, time_card)
           stream.synchronize()
 
           if shared_output_tensors is not None:
@@ -154,7 +154,7 @@ def runner(input_queue, output_queue, print_summary,
               else:
                 # no need to pass any signals, just enqueue empty signal
                 signal = None
-              output_queue.put_nowait(((signal, non_tensor_outputs), time_card))
+              output_queue.put_nowait((signal, non_tensor_outputs, time_card))
 
             except Full:
               print('[WARNING] Queue between runner step %d and %d is full. '

--- a/runner_model.py
+++ b/runner_model.py
@@ -45,25 +45,37 @@ class RunnerModel:
     """
     raise NotImplementedError
 
-  def __call__(self, input):
+  def __call__(self, tensors, non_tensors, time_card):
     """Perform inference on this model with the given input.
 
     We purposely follow PyTorch's convention of using __call__ for inference.
-    The input parameter is a pair of tensor tuples and a non-tensor object
-    (which could also be a tuple, but does not necessaily have to be), e.g.,
-    ((tensor1, tensor2, tensor3), string). In case the previous step does not
-    provide any tensor outputs, the tensor tuple is set to None. This is also
-    true for the non-tensor object.
+    The first input parameter is a tuple of tensors. Note that even if there is
+    only one tensor input, this parameter is still a tuple and not a standalone
+    tensor object. In that case, you can extract the single tensor simply by
+    doing `tensor = tensors[0]`. Moreover, this tuple is set to None if no
+    tensor output has been provided by the previous step.
 
-    Note that even if there is only one tensor input, the tensor tuple is still
-    a tuple and not a standalone tensor object. In that case, one way you can
-    extract the single tensor from `input` is `(tensor,), _ = input`. This is
-    NOT true for the non-tensor object; the non-tensor output from the previous
-    step can be literally anything.
+    The second input parameter is a non-tensor object. Unlike the tensor tuple,
+    this parameter does not have any restrictions regarding its type.
+    It could be a tuple, or a primitive string, or anything. This parameter is
+    set to None if no non-tensor output has been given from the previous step.
 
-    This tuple format is the same for the output. For the tensor outputs, make
+    The third input parameter is a TimeCard object which holds various timings
+    regarding this particular inference item. You are allowed to check, use, or
+    even manipulate its contents in case your implementation involves any
+    system-related aspects. Otherwise, it is perfectly fine to completely ignore
+    this.
+
+
+    This format is the same for the output. For the tensor outputs, make
     sure to return None if there is no output, and to return a tuple if there
-    is at least one output. Also don't forget to return None for the non-tensor
-    object if you don't have any non-tensor output.
+    is at least one output. For the non-tensor output, either return an object
+    in any desired format (tuples, lists, and other nested data structures are
+    all allowed), or None if there is no such output. For the TimeCard object,
+    return the input parameter as-is if you did not touch it, or a corresponding
+    TimeCard object if you did.
+
+    Return the outputs in the form of a tuple, e.g.,
+    `return (tensor,), non_tensor, time_card`.
     """
     raise NotImplementedError


### PR DESCRIPTION
This PR reorganizes `RunnerModel.__call__()` to explicitly receive three input parameters, instead of the original one parameter. The three parameters are 1) tensors, 2) non_tensors, and 3) the associated TimeCard object. This way, we can clearly see which is which instead of having to parse the input in an awkward format, like `(tensor,), _ = input`.

I've also changed the enqueue/dequeue format for intermediate queues to match the new signature, for the sake of consistency.