### PR TITLE
Include GPU path per video inference in logs

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -76,6 +76,7 @@ def runner(input_queue, output_queue, print_summary,
 
           signal, non_tensor_inputs, time_card = tpl
 
+          time_card.add_gpu(g_idx)
           time_card.record('runner%d_start' % step_idx)
 
           if signal is not None:


### PR DESCRIPTION
Closes #65.

This PR modifies TimeCard objects to record not only timings but GPU device index info as well. This allows us to completely track which GPU path each video segment took during inference.

At the runner, `TimeCard.add_gpu(gpu)` is called to record the current GPU. Internally, the GPU path is maintained as a list of GPU indices. When two or more TimeCards with different GPU lineages are merged, we simply concat the different GPU indices into one tuple to avoid losing any data.
As a result, a merged TimeCard can have a GPU path record such as the following:
```python
[
 (0,),       # this TimeCard was on GPU 0, before being forked
 (1, 2, 3),  # the three segments of this video passed through GPU 1, 2 & 3
 (-1,)       # all three segments were collected on CPU and aggregated into one
]
```
The tuple type is used even when only one GPU was used in one step, for the sake of type consistency (this slightly simplifies the logging code).