### PR TITLE
Hotfix: Remove nvvl loader close() call from R(2+1)D impl

### DIFF
--- a/models/r2p1d/model.py
+++ b/models/r2p1d/model.py
@@ -140,9 +140,6 @@ class R2P1DLoader(RunnerModel):
     frames = frames.permute(0, 2, 1, 3, 4)
     return (frames,), None, time_card
 
-  def __del__(self):
-    self.loader.close()
-
   def input_shape(self):
     return None
 
@@ -213,9 +210,6 @@ class R2P1DSingleStep(RunnerModel):
     frames = frames.permute(0, 2, 1, 3, 4)
 
     return (self.model(frames),), None, time_card
-
-  def __del__(self):
-    self.loader.close()
 
   def input_shape(self):
     return None


### PR DESCRIPTION
This PR removes the `__del__` function from our R(2+1)D implementation, which internally invokes `nvvl.RnBLoader.close()` to try and release any resources being used by the NVVL loader. Contrary to what the function is trying to do, this actually prevents processes from exiting even after the main process has terminated. I think this issue has something do with C++ side pointers not being freed correctly, though I haven't been able to identify the exact cause at the moment.

For now, I propose to simply apply this fix since the benchmark seems to safely exit this way.