### PR TITLE
Implement input batching as a runner

### DIFF
--- a/batcher.py
+++ b/batcher.py
@@ -1,0 +1,34 @@
+from rnb_logging import TimeCardList
+from runner_model import RunnerModel
+import torch
+
+class Batcher(RunnerModel):
+  def __init__(self, device, batch=1):
+    super(Batcher, self).__init__(device)
+
+    self.stacked_tensors = []
+    self.stacked_time_cards = []
+    self.batch = batch
+
+  @staticmethod
+  def output_shape():
+    return ((15, 3, 8, 112, 112),)
+
+  def __call__(self, tensors, non_tensors, time_card):
+    if self.batch <= 1:
+      return tensors, non_tensors, time_card
+
+    tensor = tensors[0]
+    self.stacked_tensors.append(tensor)
+    self.stacked_time_cards.append(time_card)
+
+    if len(self.stacked_tensors) < self.batch:
+      return None, None, None
+
+    tensor_batch = torch.cat(self.stacked_tensors, dim=0)
+    time_card_list = TimeCardList(self.stacked_time_cards)
+
+    self.stacked_tensors = []
+    self.stacked_time_cards = []
+
+    return (tensor_batch,), None, time_card_list

--- a/benchmark.py
+++ b/benchmark.py
@@ -135,6 +135,7 @@ if __name__ == '__main__':
   import json
   import os
   import shutil
+  import sys
   import time
   from arg_utils import *
   from datetime import datetime as dt
@@ -149,18 +150,26 @@ if __name__ == '__main__':
   parser = argparse.ArgumentParser()
   parser.add_argument('-mi', '--mean_interval_ms',
                       help='Mean event interval time (Poisson), milliseconds',
-                      type=nonnegative_int, default=100)
+                      type=nonnegative_int, default=3)
   parser.add_argument('-b', '--batch_size', help='Video batch size per replica',
                       type=positive_int, default=1)
   parser.add_argument('-v', '--videos', help='Total number of videos to run',
                       type=positive_int, default=2000)
   parser.add_argument('-qs', '--queue_size',
                       help='Maximum queue size for inter-process queues',
-                      type=positive_int, default=500)
+                      type=positive_int, default=50000)
   parser.add_argument('-c', '--config_file_path',
                       help='File path of the pipeline configuration file',
                       type=str, default='config/r2p1d-whole.json')
+  parser.add_argument('--check',
+                      help='Quick check if all imports are working correctly',
+                      action='store_true')
   args = parser.parse_args()
+
+  if args.check:
+    print('RnB is ready to go!')
+    sys.exit()
+
   print('Args:', args)
   
   sanity_check(args)
@@ -276,7 +285,8 @@ if __name__ == '__main__':
   time_end = time.time()
   print('FINISH! %f' % time_end)
   total_time = time_end - time_start
-  print('That took %f seconds' % total_time)
+  print('Time: %f sec' % total_time)
+  print('Number of videos: %d videos' % args.videos)
 
 
   print('Waiting for child processes to return...')

--- a/config/baseline.json
+++ b/config/baseline.json
@@ -1,0 +1,20 @@
+{
+  "video_path_iterator": "models.r2p1d.model.R2P1DVideoPathIterator",
+  "pipeline": [
+    {
+      "model": "models.r2p1d.model.R2P1DLoader",
+      "queue_groups": [
+        { "gpus": [0,1,2,3,4,5,6,7], "out_queues": [0] }
+      ],
+      "num_shared_tensors": 20
+    },
+    {
+      "model": "models.r2p1d.model.R2P1DRunner",
+      "queue_groups": [
+        { "gpus": [0,1,2,3,4,5,6,7], "in_queue": 0  }
+      ],
+      "start_index": 1,
+      "end_index": 5
+    }
+  ]
+}

--- a/config/rnb.json
+++ b/config/rnb.json
@@ -1,0 +1,29 @@
+{
+  "video_path_iterator": "models.r2p1d.model.R2P1DVideoPathIterator",
+  "pipeline": [
+    {
+      "model": "models.r2p1d.model.R2P1DLoader",
+      "queue_groups": [
+        { "gpus": [0,1,2,3,4,5,6,7], "out_queues": [0,1],
+          "queue_selector": "models.r2p1d.model.LargeSmallSelector" }
+      ],
+      "num_shared_tensors": 20
+    },
+    {
+      "model": "batcher.Batcher",
+      "queue_groups": [
+        { "gpus": [0], "in_queue": 0, "out_queues": [0], "batch": 3 },
+        { "gpus": [1], "in_queue": 1, "out_queues": [0] }
+      ],
+      "num_shared_tensors": 50
+    },
+    {
+      "model": "models.r2p1d.model.R2P1DRunner",
+      "queue_groups": [
+        { "gpus": [0,1,2,3,4,5,6,7], "in_queue": 0 }
+      ],
+      "start_index": 1,
+      "end_index": 5
+    }
+  ]
+}

--- a/models/r2p1d/sampler.py
+++ b/models/r2p1d/sampler.py
@@ -22,7 +22,8 @@ from nvvl import Sampler
 import random
 
 class R2P1DSampler(Sampler):
-  def __init__(self, clip_length=8, num_clips=10):
+  def __init__(self, clip_length=8, num_clips=10,
+               num_clips_population=[1, 15], num_clips_weights=[10, 1]):
     """
     Args:
       clip_length: number of frames per clip
@@ -30,6 +31,8 @@ class R2P1DSampler(Sampler):
     """
     self.clip_length = clip_length
     self.num_clips = num_clips
+    self.num_clips_population = num_clips_population
+    self.num_clips_weights = num_clips_weights
 
   def _sample(self, length, num_clips):
     if num_clips == 0:
@@ -50,4 +53,10 @@ class R2P1DSampler(Sampler):
     return [item for sublist in frame_indices for item in sublist]
 
   def sample(self, length):
-    return self._sample(length, self.num_clips)
+    if self.num_clips_population is not None and \
+        self.num_clips_weights is not None:
+      num_clips = random.choices(self.num_clips_population,
+                                 self.num_clips_weights)[0]
+    else:
+      num_clips = self.num_clips
+    return self._sample(length, num_clips)

--- a/rnb_logging.py
+++ b/rnb_logging.py
@@ -123,6 +123,25 @@ class TimeCard:
     return merged_time_card
 
 
+class TimeCardList:
+  def __init__(self, time_cards):
+    self.time_cards = time_cards
+
+
+  def record(self, key):
+    for time_card in self.time_cards:
+      time_card.record(key)
+
+
+  def add_gpu(self, gpu):
+    for time_card in self.time_cards:
+      time_card.add_gpu(gpu)
+
+
+  def fork(self, sub_id):
+    raise NotImplementedError('TimeCardLists cannot be forked.')
+
+
 class TimeCardSummary:
   """An aggregator class for TimeCards."""
   def __init__(self):

--- a/runner.py
+++ b/runner.py
@@ -21,6 +21,7 @@ def runner(input_queue, output_queues, queue_selector_path, print_summary,
   from control import TerminationFlag, Signal
   from utils.class_utils import load_class
 
+  # TODO #72: Investigate `torch.backends.cudnn.benchmark`
   torch.backends.cudnn.benchmark = True
 
   # We need to explicitly set the default device of this process to be g_idx.


### PR DESCRIPTION
This PR allows batching of inputs in the form a runner that can be inserted into a pipeline configuration as its own step. This PR also includes a few minor tweaks for the upcoming TTA evaluation.

The `Batcher` class in `batcher.py` implements the batching functionality. I'd say the current class impl is agnostic to our r2p1d model and quite generally applicable to other models, except for maybe the hard-coded output shape. Batching involves some changes in `runner.py` as well, such as incrementing the global inference counter by more than one when a batched instance is observed at the end of the pipeline. I've also added a new `TimeCardList` class in `rnb_logging.py` to represent a set of `TimeCard`s for a batched instance.

All other changes are for the TTA evaluation. A short checklist:
* Output "RnB is ready to go!” when the command line argument `--check` is given
* Add `config/baseline.json` and `config/rnb.json`
* Set default parameters for various command line arguments so that the test command is not too long: `CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python benchmark.py -v 10000 -c config/rnb.json`
* Output "Time: A sec" & "Number of videos: B videos" at the end of an experiment